### PR TITLE
fix: RevitVersion mismatch for R2026 property group

### DIFF
--- a/RevitAddinTemplate.Multiversion/ProjectTemplate.csproj
+++ b/RevitAddinTemplate.Multiversion/ProjectTemplate.csproj
@@ -131,7 +131,7 @@
         <DefineConstants>DEBUG;R2026</DefineConstants>
         <TargetFramework>net8.0-windows</TargetFramework>
         <AssemblyName>$(AssemblyName)</AssemblyName>
-        <RevitVersion>2025</RevitVersion>
+        <RevitVersion>2026</RevitVersion>
         <WarningLevel>4</WarningLevel>
         <LangVersion>latest</LangVersion>
         <StartAction>Program</StartAction>


### PR DESCRIPTION
R2026 compilation symbol had an incorrect value in the RevitVersion variable, making the post-build events not work as expected.